### PR TITLE
feat: publish shared metrics OpenAPI schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+REST service that receives application metadata, serializes it with `soknadarkiv-schema`, and publishes it to Kafka for the archiving flow.

--- a/api/src/main/resources/soknadsmottaker-api.yml
+++ b/api/src/main/resources/soknadsmottaker-api.yml
@@ -7,7 +7,7 @@ info:
     [Soknadsfillager](https://www.github.com/navikt/soknadsfillager), before calling Soknadsmottaker.
     When Soknadsmottaker receives data, it will be converted, serialized as an Avro message and put on a
     Kafka topic.
-  version: 2.0.0
+  version: 2.1.0
   title: Soknadsmottaker
   contact:
     name: team-soknad
@@ -232,6 +232,29 @@ components:
       x-enum-varnames: [ "OK", "ISSUE", "DOWN" ]
       description: Operativ status på applikasjonen. (OK=Tjeneste er tilgjengelig og fungerer normalt, ISSUE=Tjeneste er tilgjengelig, men med begrenset funksjonalitet/kapasitet, DOWN=Tjeneste er utilgjengelig)
       example: OK
+
+    InnsendingMetrics:
+      type: object
+      required:
+        - application
+        - action
+        - startTime
+        - duration
+      properties:
+        application:
+          type: string
+          description: Name of the application emitting the metric.
+        action:
+          type: string
+          description: Action measured by the metric.
+        startTime:
+          type: string
+          format: date-time
+          description: ISO-8601 timestamp at which the measured action started.
+        duration:
+          type: integer
+          format: int64
+          description: Duration of the measured action in milliseconds.
 
     AvsenderDto:
       type: object


### PR DESCRIPTION
## Summary
- add the shared InnsendingMetrics OpenAPI schema
- bump the published API specification to 2.1.0

Closes #205