### PR TITLE
feat(kafka): publish metrics as JSON v3

### DIFF
--- a/.nais/config-preprod.json
+++ b/.nais/config-preprod.json
@@ -4,7 +4,7 @@
 	"ingress": [
 		"https://soknadsmottaker-gcp.intern.dev.nav.no"
 	],
-	"kafka-metrics-topic": "team-soknad.privat-soknadinnsending-metrics-v2-dev",
+	"kafka-metrics-topic": "team-soknad.privat-soknadinnsending-metrics-v3-dev",
 	"kafka-brukernotifikasjon-done-topic": "min-side.aapen-brukervarsel-v1",
 	"kafka-brukernotifikasjon-beskjed-topic": "min-side.aapen-brukervarsel-v1",
 	"kafka-brukernotifikasjon-oppgave-topic": "min-side.aapen-brukervarsel-v1",

--- a/.nais/config-prod.json
+++ b/.nais/config-prod.json
@@ -4,7 +4,7 @@
 	"ingress": [
 		"https://soknadsmottaker-gcp.intern.nav.no"
 	],
-	"kafka-metrics-topic": "team-soknad.privat-soknadinnsending-metrics-v2",
+	"kafka-metrics-topic": "team-soknad.privat-soknadinnsending-metrics-v3",
 	"kafka-brukernotifikasjon-done-topic": "min-side.aapen-brukervarsel-v1",
 	"kafka-brukernotifikasjon-beskjed-topic": "min-side.aapen-brukervarsel-v1",
 	"kafka-brukernotifikasjon-oppgave-topic": "min-side.aapen-brukervarsel-v1",

--- a/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/InnsendingMetricsJsonSerializer.kt
+++ b/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/InnsendingMetricsJsonSerializer.kt
@@ -1,0 +1,17 @@
+package no.nav.soknad.arkivering.soknadsmottaker.config
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
+import org.apache.kafka.common.serialization.Serializer
+
+class InnsendingMetricsJsonSerializer : Serializer<InnsendingMetrics> {
+	private val objectMapper = jacksonObjectMapper().apply {
+		registerModule(JavaTimeModule())
+		disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+	}
+
+	override fun serialize(topic: String?, data: InnsendingMetrics?): ByteArray? =
+		data?.let(objectMapper::writeValueAsBytes)
+}

--- a/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/KafkaConfig.kt
+++ b/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/KafkaConfig.kt
@@ -4,7 +4,7 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGI
 import io.confluent.kafka.serializers.KafkaAvroSerializer
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig.USER_INFO_CONFIG
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG
 import org.apache.kafka.clients.producer.ProducerConfig.*
 import org.apache.kafka.common.config.SaslConfigs.SASL_MECHANISM
@@ -22,7 +22,10 @@ class KafkaSetup(private val kafkaConfig: KafkaConfig) {
 	private val stringKeySerializerClass = StringSerializer::class.java
 	private val stringValueSerializerClass = StringSerializer::class.java
 
-	fun <T : Serializer<*>> createKafkaConfig(keySerializer: Class<T>, valueSerializer: Class<T>? = null): HashMap<String, Any> {
+	fun createKafkaConfig(
+		keySerializer: Class<out Serializer<*>>,
+		valueSerializer: Class<out Serializer<*>>? = null
+	): HashMap<String, Any> {
 
 		return HashMap<String, Any>().also {
 			it[BOOTSTRAP_SERVERS_CONFIG] = kafkaConfig.kafkaBrokers
@@ -50,7 +53,10 @@ class KafkaSetup(private val kafkaConfig: KafkaConfig) {
 	}
 
 	@Bean
-	fun metricProducerFactory() = DefaultKafkaProducerFactory<String, InnsendingMetrics>(createKafkaConfig(stringKeySerializerClass))
+	fun metricProducerFactory() =
+		DefaultKafkaProducerFactory<String, InnsendingMetrics>(
+			createKafkaConfig(stringKeySerializerClass, InnsendingMetricsJsonSerializer::class.java)
+		)
 
 	@Bean
 	fun beskjedNotificationFactory() = DefaultKafkaProducerFactory<String, String>(createKafkaConfig(stringKeySerializerClass, stringValueSerializerClass))

--- a/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/service/InnsendingService.kt
+++ b/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/service/InnsendingService.kt
@@ -1,13 +1,16 @@
 package no.nav.soknad.arkivering.soknadsmottaker.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.model.Innsending
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.supervision.InnsendtMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.supervision.MetricNames
 import no.nav.soknad.arkivering.soknadsmottaker.util.mapTilInnsendingTopicMsg
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 @Service
 class InnsendingService(
@@ -18,7 +21,7 @@ class InnsendingService(
 	private val logger = LoggerFactory.getLogger(javaClass)
 
 	fun publishToNoLoginTopic(key: String, innsending: Innsending) {
-		val startTime = System.currentTimeMillis()
+		val startTime = OffsetDateTime.now(ZoneOffset.UTC)
 		try {
 			publishSubmission(key, innsending, isLoggedIn=false)
 			logger.info("$key: Not logged in, published to kanal: ${innsending.kanal}, skjemanr: ${innsending.skjemanr}")
@@ -34,7 +37,7 @@ class InnsendingService(
 
 
 	fun publishToLoggedinTopic(key: String, innsending: Innsending) {
-		val startTime = System.currentTimeMillis()
+		val startTime = OffsetDateTime.now(ZoneOffset.UTC)
 		try {
 			publishSubmission(key, innsending, isLoggedIn=true)
 			logger.info("$key: Logged in, published to kanal: ${innsending.kanal}, skjemanr: ${innsending.skjemanr}")
@@ -54,9 +57,9 @@ class InnsendingService(
 		kafkaSender.publishSubmission( key, valueAsString, isLoggedIn)
 	}
 
-	private fun tryPublishingMetrics(key: String, startTime: Long) {
+	private fun tryPublishingMetrics(key: String, startTime: OffsetDateTime) {
 		try {
-			val duration = System.currentTimeMillis() - startTime
+			val duration = Duration.between(startTime, OffsetDateTime.now(ZoneOffset.UTC)).toMillis()
 
 			val metric = InnsendingMetrics("soknadsmottaker", "publish to kafka", startTime, duration)
 			kafkaSender.publishMetric(key, metric)

--- a/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/service/KafkaSender.kt
+++ b/mottaker/src/main/kotlin/no/nav/soknad/arkivering/soknadsmottaker/service/KafkaSender.kt
@@ -1,7 +1,7 @@
 package no.nav.soknad.arkivering.soknadsmottaker.service
 
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.config.KafkaConfig
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.slf4j.LoggerFactory

--- a/mottaker/src/main/resources/application.yml
+++ b/mottaker/src/main/resources/application.yml
@@ -91,7 +91,7 @@ kafkaconfig:
   keystorePath: ${KAFKA_KEYSTORE_PATH}
   credstorePassword: ${KAFKA_CREDSTORE_PASSWORD}
 
-  metricsTopic: ${KAFKA_METRICS_TOPIC:privat-soknadinnsending-metrics-v1-dev}
+  metricsTopic: ${KAFKA_METRICS_TOPIC:privat-soknadinnsending-metrics-v3-dev}
   brukernotifikasjonDoneTopic: ${KAFKA_BRUKERNOTIFIKASJON_DONE_TOPIC:min-side.aapen-brukernotifikasjon-done-v1}
   brukernotifikasjonBeskjedTopic: ${KAFKA_BRUKERNOTIFIKASJON_BESKJED_TOPIC:min-side.aapen-brukernotifikasjon-beskjed-v1}
   brukernotifikasjonOppgaveTopic: ${KAFKA_BRUKERNOTIFIKASJON_OPPGAVE_TOPIC:min-side.aapen-brukernotifikasjon-oppgave-v1}
@@ -129,10 +129,9 @@ kafkaconfig:
   keystorePath: path
   credstorePassword: pass
 
-  metricsTopic: ${KAFKA_METRICS_TOPIC:privat-soknadinnsending-metrics-v1-dev}
+  metricsTopic: ${KAFKA_METRICS_TOPIC:privat-soknadinnsending-metrics-v3-dev}
   brukernotifikasjonDoneTopic: ${KAFKA_BRUKERNOTIFIKASJON_DONE_TOPIC:min-side.aapen-brukernotifikasjon-done-v1}
   brukernotifikasjonBeskjedTopic: ${KAFKA_BRUKERNOTIFIKASJON_BESKJED_TOPIC:min-side.aapen-brukernotifikasjon-beskjed-v1}
   brukernotifikasjonOppgaveTopic: ${KAFKA_BRUKERNOTIFIKASJON_OPPGAVE_TOPIC:min-side.aapen-brukernotifikasjon-oppgave-v1}
   loggedinSubmissionTopic: ${KAFKA_LOGGEDIN_SUBMISSION_TOPIC:privat-loggedinsubmission-v1-dev}
   nologinSubmissionTopic: ${KAFKA_NOLOGIN_SUBMISSION_TOPIC:privat-nologinsubmission-v1-dev}
-

--- a/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/SoknadsmottakerApplicationTests.kt
+++ b/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/SoknadsmottakerApplicationTests.kt
@@ -29,6 +29,6 @@ class SoknadsmottakerApplicationTests {
 	@Test
 	fun `Reads environment variables correctly`() {
 		assertEquals("privat-loggedinsubmission-v1-dev", kafkaConfig.loggedinSubmissionTopic)
-		assertEquals("privat-soknadinnsending-metrics-v1-dev", kafkaConfig.metricsTopic)
+		assertEquals("privat-soknadinnsending-metrics-v3-dev", kafkaConfig.metricsTopic)
 	}
 }

--- a/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/InnsendingMetricsJsonSerializerTest.kt
+++ b/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/config/InnsendingMetricsJsonSerializerTest.kt
@@ -1,0 +1,60 @@
+package no.nav.soknad.arkivering.soknadsmottaker.config
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
+import org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG
+import org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class InnsendingMetricsJsonSerializerTest {
+	private val startTime = OffsetDateTime.of(2026, 8, 6, 10, 30, 15, 0, ZoneOffset.UTC)
+	private val metric = InnsendingMetrics(
+		application = "soknadsmottaker",
+		action = "publish to kafka",
+		startTime = startTime,
+		duration = 123L
+	)
+
+	@Test
+	fun `serializes generated metrics model as plain JSON`() {
+		val serialized = InnsendingMetricsJsonSerializer().serialize("metrics-v3", metric)
+		val json = jacksonObjectMapper().readTree(serialized)
+
+		assertEquals("soknadsmottaker", json["application"].asText())
+		assertEquals("publish to kafka", json["action"].asText())
+		assertEquals("2026-08-06T10:30:15Z", json["startTime"].asText())
+		assertEquals(123L, json["duration"].asLong())
+		assertEquals(4, json.size())
+	}
+
+	@Test
+	fun `serializes null as a Kafka tombstone`() {
+		assertNull(InnsendingMetricsJsonSerializer().serialize("metrics-v3", null))
+	}
+
+	@Test
+	fun `configures String keys and JSON metrics values`() {
+		val properties = KafkaSetup(kafkaConfig()).metricProducerFactory().configurationProperties
+
+		assertEquals(StringSerializer::class.java, properties[KEY_SERIALIZER_CLASS_CONFIG])
+		assertEquals(InnsendingMetricsJsonSerializer::class.java, properties[VALUE_SERIALIZER_CLASS_CONFIG])
+	}
+
+	private fun kafkaConfig() = KafkaConfig().apply {
+		namespace = "team-soknad"
+		secure = "FALSE"
+		schemaRegistryUsername = "user"
+		schemaRegistryPassword = "password"
+		schemaRegistryUrl = "http://localhost:8081"
+		kafkaBrokers = "localhost:29092"
+		truststorePath = "truststore"
+		keystorePath = "keystore"
+		credstorePassword = "password"
+		metricsTopic = "privat-soknadinnsending-metrics-v3-dev"
+	}
+}

--- a/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/LoggedinSubmissionTests.kt
+++ b/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/LoggedinSubmissionTests.kt
@@ -5,11 +5,11 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.slot
 import io.prometheus.metrics.model.registry.PrometheusRegistry
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.SoknadsmottakerApplication
 import no.nav.soknad.arkivering.soknadsmottaker.config.KafkaConfig
 import no.nav.soknad.arkivering.soknadsmottaker.model.AvsenderDto
 import no.nav.soknad.arkivering.soknadsmottaker.model.BrukerDto
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingTopicMsg
 import no.nav.soknad.arkivering.soknadsmottaker.service.KafkaSender
 import no.nav.soknad.arkivering.soknadsmottaker.supervision.InnsendtMetrics
@@ -108,6 +108,9 @@ class LoggedinSubmissionTests {
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_OK.name,"HJE"), "Should increase counter by 1")
@@ -166,6 +169,9 @@ class LoggedinSubmissionTests {
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_OK.name,"HJE"), "Should increase counter by 1")
@@ -214,6 +220,9 @@ class LoggedinSubmissionTests {
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_OK.name,"HJE"), "Should increase counter by 1")

--- a/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/NologinSubmissionTests.kt
+++ b/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/NologinSubmissionTests.kt
@@ -4,11 +4,11 @@ import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.slot
 import io.prometheus.metrics.model.registry.PrometheusRegistry
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.SoknadsmottakerApplication
 import no.nav.soknad.arkivering.soknadsmottaker.config.KafkaConfig
 import no.nav.soknad.arkivering.soknadsmottaker.model.AvsenderDto
 import no.nav.soknad.arkivering.soknadsmottaker.model.BrukerDto
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingTopicMsg
 import no.nav.soknad.arkivering.soknadsmottaker.service.KafkaSender
 import no.nav.soknad.arkivering.soknadsmottaker.supervision.InnsendtMetrics
@@ -107,6 +107,9 @@ lateinit var prometheusRegistry: PrometheusRegistry
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET.name,"HJE"), "Should increase counter by 1")
@@ -165,6 +168,9 @@ lateinit var prometheusRegistry: PrometheusRegistry
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET.name,"HJE"), "Should increase counter by 1")
@@ -214,6 +220,9 @@ lateinit var prometheusRegistry: PrometheusRegistry
 		assertEquals(soknad.innsendingsId, metricKey.captured, "Should use innsendingsId as metric key")
 		assertTrue(metricMsg.isCaptured, "Should capture metric message")
 		assertEquals("soknadsmottaker", metricMsg.captured.application, "Metrics should have correct application name")
+		assertEquals("publish to kafka", metricMsg.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricMsg.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricMsg.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 		assertEquals(errorsBefore + 1.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET_ERROR.name, "HJE"), "Should not cause errors")
 		assertEquals(sentInBefore + 0.0, metrics.mottattSoknadGet(MetricNames.INNSENDT_UINNLOGGET.name,"HJE"), "Should increase counter by 1")
@@ -221,4 +230,3 @@ lateinit var prometheusRegistry: PrometheusRegistry
 	}
 
 }
-

--- a/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/RestEndpointTest.kt
+++ b/mottaker/src/test/kotlin/no/nav/soknad/arkivering/soknadsmottaker/rest/RestEndpointTest.kt
@@ -14,9 +14,9 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.*
 import io.prometheus.metrics.model.registry.PrometheusRegistry
-import no.nav.soknad.arkivering.avroschemas.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.model.AvsenderDto
 import no.nav.soknad.arkivering.soknadsmottaker.model.BrukerDto
+import no.nav.soknad.arkivering.soknadsmottaker.model.InnsendingMetrics
 import no.nav.soknad.arkivering.soknadsmottaker.service.KafkaSender
 import no.nav.soknad.arkivering.soknadsmottaker.utils.createInnsending
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -134,6 +134,9 @@ class RestEndpointTest {
 			"soknadsmottaker", metricsDataSlot.captured.application,
 			"Metrics should have correct application name"
 		)
+		assertEquals("publish to kafka", metricsDataSlot.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricsDataSlot.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricsDataSlot.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 	}
 
@@ -186,6 +189,9 @@ class RestEndpointTest {
 			"soknadsmottaker", metricsDataSlot.captured.application,
 			"Metrics should have correct application name"
 		)
+		assertEquals("publish to kafka", metricsDataSlot.captured.action, "Metrics should have correct action")
+		assertEquals(0, metricsDataSlot.captured.startTime.offset.totalSeconds, "Metrics startTime should be UTC")
+		assertTrue(metricsDataSlot.captured.duration >= 0, "Metrics duration should be milliseconds")
 
 	}
 

--- a/topicconfig/soknadinnsending-metrics-v3-dev.json
+++ b/topicconfig/soknadinnsending-metrics-v3-dev.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "kafka.nais.io/v1",
+  "kind": "Topic",
+  "metadata": {
+    "name": "privat-soknadinnsending-metrics-v3-dev",
+    "namespace": "team-soknad",
+    "labels": {
+      "team": "team-soknad"
+    }
+  },
+  "spec": {
+    "config": {
+      "partitions": 12
+    },
+    "acl": [
+      {
+        "application": "soknadsarkiverer",
+        "team": "team-soknad",
+        "access": "readwrite"
+      },
+      {
+        "application": "soknadsmottaker",
+        "team": "team-soknad",
+        "access": "readwrite"
+      }
+    ],
+    "pool": "nav-dev"
+  }
+}

--- a/topicconfig/soknadinnsending-metrics-v3-prod.json
+++ b/topicconfig/soknadinnsending-metrics-v3-prod.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "kafka.nais.io/v1",
+  "kind": "Topic",
+  "metadata": {
+    "name": "privat-soknadinnsending-metrics-v3",
+    "namespace": "team-soknad",
+    "labels": {
+      "team": "team-soknad"
+    }
+  },
+  "spec": {
+    "config": {
+      "partitions": 12
+    },
+    "acl": [
+      {
+        "application": "soknadsarkiverer",
+        "team": "team-soknad",
+        "access": "readwrite"
+      },
+      {
+        "application": "soknadsmottaker",
+        "team": "team-soknad",
+        "access": "readwrite"
+      }
+    ],
+    "pool": "nav-prod"
+  }
+}


### PR DESCRIPTION
## Summary
- publish the OpenAPI-generated `InnsendingMetrics` model as plain JSON
- move every metrics producer configuration to `metrics-v3` with no dual-write
- provision v3 topics and update producer/REST coverage

## Testing
- focused `soknadsmottaker` tests: 18 passed
- `archiving-infrastructure/run-end-to-end-tests.sh`: 13 passed

Closes #206

Depends on navikt/soknadsarkiverer#265 being deployed first, as specified in navikt/soknadsarkiverer#260.